### PR TITLE
Enhance Pages: /algorithms path, landing page, and click analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ This is a multi-language mono-repo where you can choose your language of choice:
 
 <a href="https://sachinlala.github.io/SimplifyLearning/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/GitHub%20Pages-Live-blue?style=for-the-badge&logo=github" alt="GitHub Pages"/></a>
 
+### Analytics
+- Click analytics powered by GoatCounter (privacy-friendly, free for OSS)
+- Dashboard (if configured): https://YOUR_SUBDOMAIN.goatcounter.com
+- Enable by adding a repository variable GC_DOMAIN set to your GoatCounter domain (e.g., mysite.goatcounter.com)
+
 -------
 
 📢 **Keywords**: `algorithms, data structures, interactive visualizations, Java, Gradle, JavaScript, 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Stars](https://img.shields.io/github/stars/sachinlala/SimplifyLearning.svg)](https://github.com/sachinlala/SimplifyLearning/stargazers)
 <a href="https://github.com/sachinlala/SimplifyLearning/actions/workflows/ci-java.yml" target="_blank" rel="noopener noreferrer"><img src="https://github.com/sachinlala/SimplifyLearning/actions/workflows/ci-java.yml/badge.svg?branch=master" alt="Java CI with Coverage"/></a>
 <a href="https://github.com/sachinlala/SimplifyLearning/actions/workflows/ci-js-pages.yml" target="_blank" rel="noopener noreferrer"><img src="https://github.com/sachinlala/SimplifyLearning/actions/workflows/ci-js-pages.yml/badge.svg?branch=master" alt="JavaScript CI with Pages"/></a>
+<a href="https://sachinlala.goatcounter.com" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/Analytics-Enabled-4A90E2?style=flat" alt="Analytics Enabled"/></a>
 
 ### <img src="https://raw.githubusercontent.com/sachinlala/SimplifyLearning/master/algorithms-js/assets/images/sl-logo.svg" width="20" height="20" alt="SL" style="vertical-align: sub; margin-right: 6px;"> Simplify Learning
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 ![Open Issues](https://img.shields.io/github/issues/sachinlala/SimplifyLearning?label=Issues&color=006400&style=flat)
 [![Forks](https://img.shields.io/github/forks/sachinlala/SimplifyLearning.svg?color=darkgreen)](https://github.com/sachinlala/SimplifyLearning/network/members)
 [![Stars](https://img.shields.io/github/stars/sachinlala/SimplifyLearning.svg)](https://github.com/sachinlala/SimplifyLearning/stargazers)
-<a href="https://github.com/sachinlala/SimplifyLearning/actions/workflows/ci-java.yml" target="_blank" rel="noopener noreferrer"><img src="https://github.com/sachinlala/SimplifyLearning/actions/workflows/ci-java.yml/badge.svg?branch=master" alt="Java CI with Coverage"/></a>
-<a href="https://github.com/sachinlala/SimplifyLearning/actions/workflows/ci-js-pages.yml" target="_blank" rel="noopener noreferrer"><img src="https://github.com/sachinlala/SimplifyLearning/actions/workflows/ci-js-pages.yml/badge.svg?branch=master" alt="JavaScript CI with Pages"/></a>
 <a href="https://sachinlala.goatcounter.com" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/Analytics-Enabled-4A90E2?style=flat" alt="Analytics Enabled"/></a>
 
 ### <img src="https://raw.githubusercontent.com/sachinlala/SimplifyLearning/master/algorithms-js/assets/images/sl-logo.svg" width="20" height="20" alt="SL" style="vertical-align: sub; margin-right: 6px;"> Simplify Learning

--- a/algorithms-js/demo.html
+++ b/algorithms-js/demo.html
@@ -8,5 +8,21 @@
 <body>
     <!-- Content will be dynamically generated -->
     <script src="assets/js/universal-loader.js"></script>
+    
+    <!-- Optional GoatCounter analytics (if configured at repo level) -->
+    <script>
+      (function(){
+        var GC = (typeof window !== 'undefined') ? (window.GC_DOMAIN || '') : '';
+        try { var p = new URLSearchParams(window.location.search); if (p.get('gc')) GC = p.get('gc'); } catch(e){}
+        var meta = document.querySelector('meta[name="gc-domain"]');
+        if (!GC && meta) GC = meta.getAttribute('content') || '';
+        if (GC) {
+          var s = document.createElement('script');
+          s.async = true; s.defer = true; s.src = 'https://gc.zgo.at/count.js';
+          s.setAttribute('data-goatcounter', 'https://' + GC + '/count');
+          document.body.appendChild(s);
+        }
+      })();
+    </script>
 </body>
 </html>

--- a/algorithms-js/index.html
+++ b/algorithms-js/index.html
@@ -110,5 +110,23 @@
     <script src="assets/js/sidebar.js"></script>
     <script src="assets/js/components.js?v=1735954700"></script>
     <script type="module" src="assets/js/ui.js"></script>
+    
+    <!-- Optional GoatCounter analytics (if configured at repo level) -->
+    <script>
+      (function(){
+        var GC = (typeof window !== 'undefined') ? (window.GC_DOMAIN || '') : '';
+        // Allow override via query param for local testing: ?gc=somedomain.goatcounter.com
+        try { var p = new URLSearchParams(window.location.search); if (p.get('gc')) GC = p.get('gc'); } catch(e){}
+        // If CI injects GC_DOMAIN at deploy time, also pick it up via a meta tag or global
+        var meta = document.querySelector('meta[name="gc-domain"]');
+        if (!GC && meta) GC = meta.getAttribute('content') || '';
+        if (GC) {
+          var s = document.createElement('script');
+          s.async = true; s.defer = true; s.src = 'https://gc.zgo.at/count.js';
+          s.setAttribute('data-goatcounter', 'https://' + GC + '/count');
+          document.body.appendChild(s);
+        }
+      })();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
This PR updates the GitHub Pages experience:

- Serve the JS UI under /algorithms (https://sachinlala.github.io/SimplifyLearning/algorithms)
- Root landing page with cards, dark/light, search, and category chips
- Optional privacy-friendly analytics (GoatCounter) via repo var GC_DOMAIN
  - Tracks page views and click events on Open/Source buttons
- algorithms-js now includes optional analytics snippet (index, demo)
- README updates:
  - Live Demo badge points to /algorithms
  - Pages + Analytics badges open in new tabs
  - Analytics section with setup instructions and dashboard link

Once merged to master, GH Pages will deploy the landing and /algorithms site; analytics will activate automatically when GC_DOMAIN is set.