### PR TITLE
Fix GitHub repository branch references from main to master

### DIFF
--- a/algorithms-js/TEMPLATE-SYSTEM.md
+++ b/algorithms-js/TEMPLATE-SYSTEM.md
@@ -67,7 +67,7 @@ npm run serve
        category: "category",
        cssPath: "../../../assets/css/styles.css",
        jsPath: "algorithm-name.js",
-       githubPath: "https://github.com/sachinlala/SimplifyLearning/blob/main/algorithms-js/src/category/algorithm-name/algorithm-name.js",
+       githubPath: "https://github.com/sachinlala/SimplifyLearning/blob/master/algorithms-js/src/category/algorithm-name/algorithm-name.js",
        algorithmFunction: "mainAlgorithmFunction",
        
        inputs: [

--- a/algorithms-js/assets/js/dynamic-template.js
+++ b/algorithms-js/assets/js/dynamic-template.js
@@ -45,7 +45,7 @@ class DynamicAlgorithmTemplate {
         const fileName = config.jsPath || `${config.name.toLowerCase().replace(/\s+/g, '-')}.js`;
         // Use the first category for the GitHub path
         const primaryCategory = Array.isArray(config.category) ? config.category[0] : config.category;
-        return `https://github.com/sachinlala/SimplifyLearning/blob/main/algorithms-js/src/${primaryCategory}/${config.name.toLowerCase().replace(/\s+/g, '-')}/${fileName}`;
+        return `https://github.com/sachinlala/SimplifyLearning/blob/master/algorithms-js/src/${primaryCategory}/${config.name.toLowerCase().replace(/\s+/g, '-')}/${fileName}`;
     }
 
     /**

--- a/algorithms-js/src/patterns/count-and-say/config.js
+++ b/algorithms-js/src/patterns/count-and-say/config.js
@@ -9,12 +9,12 @@ const config = {
     problem: "Generate the nth term of the Count and Say sequence by reading and describing the digits of the previous term.",
     cssPath: "../../../assets/css/styles.css",
     jsPath: "count-and-say.js",
-    githubPath: "https://github.com/sachinlala/SimplifyLearning/blob/main/algorithms-js/src/patterns/count-and-say/count-and-say.js",
+    githubPath: "https://github.com/sachinlala/SimplifyLearning/blob/master/algorithms-js/src/patterns/count-and-say/count-and-say.js",
     
     // Multi-language source code paths
     sourceCode: {
-        javascript: "https://github.com/sachinlala/SimplifyLearning/blob/main/algorithms-js/src/patterns/count-and-say/count-and-say.js",
-        java: "https://github.com/sachinlala/SimplifyLearning/blob/main/algorithms-java/src/main/java/com/algorithms/sequences/CountAndSay.java",
+        javascript: "https://github.com/sachinlala/SimplifyLearning/blob/master/algorithms-js/src/patterns/count-and-say/count-and-say.js",
+        java: "https://github.com/sachinlala/SimplifyLearning/blob/master/algorithms-java/src/main/java/com/algorithms/sequences/CountAndSay.java",
         python: "", // Coming soon
         go: "" // Coming soon
     },

--- a/algorithms-js/src/sort/bubble-sort/config.js
+++ b/algorithms-js/src/sort/bubble-sort/config.js
@@ -8,12 +8,12 @@ const config = {
     problem: "Sort an array of elements by repeatedly comparing adjacent elements and swapping them if they are in the wrong order.",
     cssPath: "../../../assets/css/styles.css",
     jsPath: "bubble-sort.js",
-    githubPath: "https://github.com/sachinlala/SimplifyLearning/blob/main/algorithms-js/src/sort/bubble-sort/bubble-sort.js",
+    githubPath: "https://github.com/sachinlala/SimplifyLearning/blob/master/algorithms-js/src/sort/bubble-sort/bubble-sort.js",
     
     // Multi-language source code paths
     sourceCode: {
-        javascript: "https://github.com/sachinlala/SimplifyLearning/blob/main/algorithms-js/src/sort/bubble-sort/bubble-sort.js",
-        java: "https://github.com/sachinlala/SimplifyLearning/blob/main/algorithms-java/src/main/java/com/algorithms/sort/BubbleSort.java",
+        javascript: "https://github.com/sachinlala/SimplifyLearning/blob/master/algorithms-js/src/sort/bubble-sort/bubble-sort.js",
+        java: "https://github.com/sachinlala/SimplifyLearning/blob/master/algorithms-java/src/main/java/com/algorithms/sort/BubbleSort.java",
         python: "", // Coming soon
         go: "" // Coming soon
     },


### PR DESCRIPTION
- Updated dynamic-template.js to generate master branch URLs
- Fixed config files for bubble-sort and count-and-say algorithms
- Updated documentation in TEMPLATE-SYSTEM.md
- All GitHub source code links now correctly point to master branch

Fixes issue where source code links were returning 404 errors due to incorrect branch references (main vs master).